### PR TITLE
Get msg instead of message

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -67,7 +67,7 @@ class PinoSentryTransport {
 
     // const user = chunk.user || {};
 
-    const message = chunk.message;
+    const message = chunk.msg;
     const stack = chunk.stack || '';
 
     Sentry.configureScope(scope => {


### PR DESCRIPTION
Pino seems to default return  ```{msg: "some-message"}```