### PR TITLE
Enhancements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-sentry",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -122,6 +122,15 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -140,18 +149,13 @@
       "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
-    "@types/pify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.2.tgz",
-      "integrity": "sha512-a5AKF1/9pCU3HGMkesgY6LsBdXHUY3WU+I2qgpU0J+I8XuJA1aFr59eS84/HP0+dxsyBSNbt+4yGI2adUpHwSg==",
-      "dev": true
-    },
-    "@types/pump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pump/-/pump-1.1.0.tgz",
-      "integrity": "sha512-YGGbsqf5o7sF8gGANP8ZYxgaRGlFgEAImx5tCvA4YKRCfqbsDQZO48UmWynZzSjbhn0ZWSlsWOcb5NwvOx8KcQ==",
+    "@types/pumpify": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pumpify/-/pumpify-1.4.1.tgz",
+      "integrity": "sha512-l7u/Dnh1OG9T7VH6TvulR0g8oE8hgIW5409mSUKi8Vxw2+JV18aTa06Sv5bvNjrD0zbsB/cuZ/iTFQgFNfzIuw==",
       "dev": true,
       "requires": {
+        "@types/duplexify": "*",
         "@types/node": "*"
       }
     },
@@ -300,6 +304,12 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -427,6 +437,17 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "duplexify": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -1062,29 +1083,24 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-    },
     "pino": {
-      "version": "5.13.4",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.4.tgz",
-      "integrity": "sha512-heeg8m8FZY8Nl3nuuD+msJUmhamqoGl7JXoTExh9YpGajzz6LYbVByUqrjbf4sCEMYFsqdcqnTJWiSY660DraQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
+      "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
       "dev": true,
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.9",
-        "pino-std-serializers": "^2.3.0",
-        "quick-format-unescaped": "^3.0.2",
-        "sonic-boom": "^0.7.5"
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
       "dev": true
     },
     "prelude-ls": {
@@ -1108,6 +1124,16 @@
         "once": "^1.3.1"
       }
     },
+    "pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "requires": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1115,9 +1141,9 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
       "dev": true
     },
     "readable-stream": {
@@ -1237,11 +1263,12 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
-      "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
       "dev": true,
       "requires": {
+        "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"
       }
     },
@@ -1258,6 +1285,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string-width": {
       "version": "4.2.0",
@@ -1417,9 +1449,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clean": "rm -rf dist",
     "build": "tsc -b tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
-    "prepublishOnly": "npm run lint && npm run build"
+    "test": "node ./test/test.js",
+    "prepublishOnly": "npm run lint && npm run build && npm run test"
   },
   "repository": "https://github.com/aandrewww/pino-sentry.git",
   "license": "MIT",
@@ -36,21 +37,19 @@
   "dependencies": {
     "@sentry/node": "^5.21.1",
     "commander": "^2.20.0",
-    "pify": "^4.0.1",
-    "pump": "^3.0.0",
+    "pumpify": "^2.0.1",
     "split2": "^3.1.1",
     "through2": "^3.0.1"
   },
   "devDependencies": {
     "@types/node": "^12.6.9",
-    "@types/pify": "^3.0.2",
-    "@types/pump": "^1.1.0",
+    "@types/pumpify": "^1.4.1",
     "@types/split2": "^2.1.6",
     "@types/through2": "^2.0.34",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
     "eslint": "^6.8.0",
-    "pino": "^5.13.1",
-    "typescript": "^3.6.3"
+    "pino": "^6.5.1",
+    "typescript": "^3.9.7"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import program from 'commander';
 
 // import pkg from '../package.json';
-import { createWriteStreamAsync } from './transport';
+import { createWriteStream } from './transport';
 
 // main cli logic
 function main() {
@@ -19,9 +19,9 @@ function main() {
     .option('--maxValueLength <maxValueLength>', 'Maximum number of chars a single value can have before it will be truncated.')
     .option('--release <release>', 'The release identifier used when uploading respective source maps.')
     .option('-l, --level <level>', 'The minimum level for a log to be reported to Sentry')
-    .action(async ({ dsn, serverName, environment, debug, sampleRate, maxBreadcrumbs, dist, logLevel, maxValueLength, release, level }) => {
+    .action(({ dsn, serverName, environment, debug, sampleRate, maxBreadcrumbs, dist, logLevel, maxValueLength, release, level }) => {
       try {
-        const writeStream = await createWriteStreamAsync({
+        const writeStream = createWriteStream({
           dsn,
           serverName,
           environment,
@@ -34,10 +34,13 @@ function main() {
           release,
           level,
         });
+        // Echo to stdout
+        process.stdin.pipe(process.stdout);
+        // Pipe to writeStream
         process.stdin.pipe(writeStream);
-        console.info('[pino-sentry] logging initialized');
+        console.info('[pino-sentry] Logging Initialized');
       } catch (error) {
-        console.log(`[pino-sentry]`, error);
+        console.log('[pino-sentry]', error);
         process.exit(1);
       }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,8 @@ function main() {
         process.stdin.pipe(writeStream);
         console.info('[pino-sentry] logging initialized');
       } catch (error) {
-        console.log(`[pino-sentry] ${error.message}`);
+        console.log(`[pino-sentry]`, error);
+        process.exit(1);
       }
     });
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -139,7 +139,7 @@ export class PinoSentryTransport {
   private validateOptions(options: PinoSentryOptions): PinoSentryOptions {
     const dsn = options.dsn || process.env.SENTRY_DSN;
     if (!dsn) {
-      throw Error('[pino-sentry] Sentry DSN must be supplied. Pass via options or `SENTRY_DSN` environment variable');
+      console.log('Warning: [pino-sentry] Sentry DSN must be supplied, otherwise logs will not be reported. Pass via options or `SENTRY_DSN` environment variable.');
     }
     if (options.level) {
       const allowedLevels = Object.keys(SeverityIota);
@@ -189,7 +189,8 @@ export function createWriteStreamAsync(options?: PinoSentryOptions): PromiseLike
       try {
         return JSON.parse(line);
       } catch (e) {
-        throw Error('logs should be in json format');
+        // Returning undefined will not run the sentryTransformer
+        return;
       }
     }),
     sentryTransformer

--- a/test/test.js
+++ b/test/test.js
@@ -1,19 +1,19 @@
-// const pinoLogger = require('../node_modules/pino');
-// const { createWriteStream } = require('../dist/index');
+const pinoLogger = require('pino');
+const { createWriteStream } = require('../dist/index');
 
-// async function main () {
-//   const SENTRY_DSN = "";
+function main() {
+  const SENTRY_DSN = "https://123@123.ingest.sentry.io/123";
 
-//   const options = {
-//     level: "info"
-//   };
+  const options = {
+    level: "info"
+  };
 
-//   const stream = createWriteStream({ dsn: SENTRY_DSN });
+  const stream = createWriteStream({ dsn: SENTRY_DSN });
 
-//   const logger = pinoLogger(options, stream);
+  const logger = pinoLogger(options, stream);
 
-//   logger.info('testtt info log');
-//   logger.error('testtt log');
-// }
+  logger.info('testtt info log');
+  logger.error('testtt log');
+}
 
-// main();
+main();


### PR DESCRIPTION
@aandrewww 


* Using `pumpify` instead of `pump` to create a Duplex stream. This allows data to be piped to the stream. Fixes: #16
* Added back test file so I don't break something
* Ignore non JSON lines (specifically anything that breaks JSON.parse)
* Allow Sentry DSN to be optional, like in `@sentry/node` module. This would be a NO-OP for reporting but still allow module to be used without DSN (like a dev environment) Fixes: #14
* Unify `createWriteStream` and `createWriteStreamAsync`. Since it's using `pumpify` we can reuse the same stream.


Tested with repro from: https://github.com/aandrewww/pino-sentry/issues/16