### PR TITLE
added attribute config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const stream = createWriteStream({
   dsn: process.env.SENTRY_DSN,
   messageAttributeKey: 'message',
   stackAttributeKey: 'trace',
-  extraAttributeKey: 'req'
+  extraAttributeKeys: ['req', 'context']
 });
 const logger = pino(opts, stream);
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ logger.info({ extra : { foo : "bar" }, msg : "Error" });
 
 ## Options (`options`)
 
+### Override Message Attributes
+
+In case the generated message does not follow the standard convention, the main attribute keys can be mapped to different values, when the stream gets created. Following attribute keys can be overridden:
+
+* `msg`
+* `extra`
+* `stack`
+
+```js
+const { createWriteStream } = require('pino-sentry');
+// ...
+const opts = { /* ... */ };
+const stream = createWriteStream({ 
+  dsn: process.env.SENTRY_DSN,
+  messageAttributeKey: 'message',
+  stackAttributeKey: 'trace',
+  extraAttributeKey: 'req'
+});
+const logger = pino(opts, stream);
+```
+
 ### Transport options
 
 * `--dsn` (`-d`): your Sentry DSN or Data Source Name (defaults to `process.env.SENTRY_DSN`)

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -47,7 +47,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   /** Minimum level for a log to be reported to Sentry from pino-sentry */
   level?: keyof typeof SeverityIota;
   messageAttributeKey?: string;
-  extraAttributeKey?: string;
+  extraAttributeKeys?: string[];
   stackAttributeKey?: string;
 }
 
@@ -55,7 +55,7 @@ export class PinoSentryTransport {
   // Default minimum log level to `debug`
   minimumLogLevel: ValueOf<typeof SeverityIota> = SeverityIota[Sentry.Severity.Debug]
   messageAttributeKey: string = 'msg';
-  extraAttributeKey: string = 'extra';
+  extraAttributeKeys: string[] = ['extra'];
   stackAttributeKey: string = 'stack';
 
   public constructor(options?: PinoSentryOptions) {
@@ -98,7 +98,12 @@ export class PinoSentryTransport {
       tags.hostname = chunk.hostname;
     }
 
-    const extra = chunk[this.extraAttributeKey] || {};
+    const extra: any = {};
+    this.extraAttributeKeys.forEach((key: string) => {
+      if(chunk[key] !== undefined) {
+        extra[key] = chunk[key];
+      }
+    });
     const message = chunk[this.messageAttributeKey];
     const stack = chunk[this.stackAttributeKey] || '';
 
@@ -143,7 +148,7 @@ export class PinoSentryTransport {
     }
 
     this.stackAttributeKey = options.stackAttributeKey ?? this.stackAttributeKey;
-    this.extraAttributeKey = options.extraAttributeKey ?? this.extraAttributeKey;
+    this.extraAttributeKeys = options.extraAttributeKeys ?? this.extraAttributeKeys;
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
 
     return {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -46,11 +46,18 @@ const SeverityIota  = {
 interface PinoSentryOptions extends Sentry.NodeOptions {
   /** Minimum level for a log to be reported to Sentry from pino-sentry */
   level?: keyof typeof SeverityIota;
+  messageAttributeKey?: string;
+  extraAttributeKey?: string;
+  stackAttributeKey?: string;
 }
 
 export class PinoSentryTransport {
   // Default minimum log level to `debug`
   minimumLogLevel: ValueOf<typeof SeverityIota> = SeverityIota[Sentry.Severity.Debug]
+  messageAttributeKey: string = 'msg';
+  extraAttributeKey: string = 'extra';
+  stackAttributeKey: string = 'stack';
+
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
   }
@@ -91,10 +98,9 @@ export class PinoSentryTransport {
       tags.hostname = chunk.hostname;
     }
 
-    const extra = chunk.extra || {};
-
-    const message = chunk.msg;
-    const stack = chunk.stack || '';
+    const extra = chunk[this.extraAttributeKey] || {};
+    const message = chunk[this.messageAttributeKey];
+    const stack = chunk[this.stackAttributeKey] || '';
 
     Sentry.configureScope(scope => {
       if (this.isObject(tags)) {
@@ -135,6 +141,10 @@ export class PinoSentryTransport {
       // Set minimum log level
       this.minimumLogLevel = SeverityIota[options.level];
     }
+
+    this.stackAttributeKey = options.stackAttributeKey ?? this.stackAttributeKey;
+    this.extraAttributeKey = options.extraAttributeKey ?? this.extraAttributeKey;
+    this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
 
     return {
       dsn,


### PR DESCRIPTION
In order to use this sentry integration also in combination with other packages such as nestjs-pino, it is required to change the log attribute keys. Otherwise sentry may not get a complete information set.