### PR TITLE
add option maxValueLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,18 @@ In case the generated message does not follow the standard convention, the main 
 * `msg`
 * `extra`
 * `stack`
+* `maxValueLength` - option to adjust max string length for values, default is 250
 
 ```js
 const { createWriteStream } = require('pino-sentry');
 // ...
 const opts = { /* ... */ };
-const stream = createWriteStream({ 
+const stream = createWriteStream({
   dsn: process.env.SENTRY_DSN,
   messageAttributeKey: 'message',
   stackAttributeKey: 'trace',
-  extraAttributeKeys: ['req', 'context']
+  extraAttributeKeys: ['req', 'context'],
+  maxValueLength: 250,
 });
 const logger = pino(opts, stream);
 ```

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -49,6 +49,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   messageAttributeKey?: string;
   extraAttributeKeys?: string[];
   stackAttributeKey?: string;
+  maxValueLength?: number;
 }
 
 export class PinoSentryTransport {
@@ -57,6 +58,7 @@ export class PinoSentryTransport {
   messageAttributeKey = 'msg';
   extraAttributeKeys = ['extra'];
   stackAttributeKey = 'stack';
+  maxValueLength = 250;
 
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
@@ -150,6 +152,7 @@ export class PinoSentryTransport {
     this.stackAttributeKey = options.stackAttributeKey ?? this.stackAttributeKey;
     this.extraAttributeKeys = options.extraAttributeKeys ?? this.extraAttributeKeys;
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
+    this.maxValueLength = options.maxValueLength ?? this.maxValueLength;
 
     return {
       dsn,


### PR DESCRIPTION
Adding option for `maxValueLength` - as it is added into [Sentry](https://github.com/getsentry/sentry-javascript/pull/1928/files)

