### PR TITLE
Add support for .breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ logger.info({ tags : { foo : "bar" }, msg : "Error" });
 
 // add extra
 logger.info({ extra : { foo : "bar" }, msg : "Error" });
+
+// add breadcrumbs
+// https://docs.sentry.io/platforms/node/enriching-events/breadcrumbs/
+logger.info({
+  msg: "Error",
+  breadcrumbs: [
+    {
+      category: "auth",
+      message: "Authenticated user " + user.email,
+      level: "info",
+    },
+  ]
+});
 ```
 
 ## Options (`options`)

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -3,6 +3,7 @@ import split from 'split2';
 import pump from 'pumpify';
 import through from 'through2';
 import * as Sentry from '@sentry/node';
+import { Breadcrumb } from '@sentry/types';
 
 type ValueOf<T> = T extends any[] ? T[number] : T[keyof T]
 
@@ -87,6 +88,7 @@ export class PinoSentryTransport {
     }
 
     const tags = chunk.tags || {};
+    const breadcrumbs: Breadcrumb[] = chunk.breadcrumbs || {};
 
     if (chunk.reqId) {
       tags.uuid = chunk.reqId;
@@ -115,6 +117,9 @@ export class PinoSentryTransport {
       }
       if (this.isObject(extra)) {
         Object.keys(extra).forEach(ext => scope.setExtra(ext, extra[ext]));
+      }
+      if (this.isObject(breadcrumbs)) {
+        Object.values(breadcrumbs).forEach(breadcrumb => scope.addBreadcrumb(breadcrumb));
       }
 
       // Capturing Errors / Exceptions

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -84,7 +84,7 @@ export class PinoSentryTransport {
     if (this.shouldLog(severity) === false) {
       setImmediate(cb);
       return;
-    };
+    }
 
     const tags = chunk.tags || {};
 


### PR DESCRIPTION
I'm trying to implement this as neutral plugin without using sentry symbols, thus using just as logger:
- https://blog.sentry.io/2020/07/22/handling-graphql-errors-using-sentry

so, need to treat `.breadcrumbs` property special to add breadcrumbs.

doc:
- https://docs.sentry.io/platforms/node/enriching-events/breadcrumbs/