### PR TITLE
✨ add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ const stream = createWriteStream({
   extraAttributeKeys: ['req', 'context'],
   maxValueLength: 250,
   sentryExceptionLevels?: Sentry.Severity['fatal', 'error', 'warning'];
+  decorateScope: (data, scope) => {
+    scope.setExtra('userId', data.userId)
+    scope.setUser({ id: data.userId })
+  }
 });
 const logger = pino(opts, stream);
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # pino-sentry
+
 [![CircleCI](https://circleci.com/gh/aandrewww/pino-sentry.svg?style=svg)](https://circleci.com/gh/aandrewww/pino-sentry)
 [![node](https://img.shields.io/badge/node-6.4.0+-brightgreen.svg)][node-url]
 [![license](https://img.shields.io/github/license/aandrewww/pino-sentry.svg)][license-url]
@@ -8,14 +8,14 @@ Load [pino](https://github.com/pinojs/pino) logs into [Sentry](https://sentry.io
 
 ## Index
 
-* [Install](#install)
-* [Usage](#usage)
+- [Install](#install)
+- [Usage](#usage)
   - [CLI](#cli)
   - [API](#api)
-* [Options](#options-options)
+- [Options](#options-options)
   - [Transport options](#transport-options)
   - [Log Level Mapping](#log-level-mapping)
-* [License](#license)
+- [License](#license)
 
 ## Install
 
@@ -34,17 +34,19 @@ node ./app.js | pino-sentry --dsn=https://******@sentry.io/12345
 ### API
 
 ```js
-const { createWriteStream } = require('pino-sentry');
+const { createWriteStream } = require("pino-sentry");
 // ...
-const opts = { /* ... */ };
+const opts = {
+  /* ... */
+};
 const stream = createWriteStream({ dsn: process.env.SENTRY_DSN });
 const logger = pino(opts, stream);
 
 // add tags
-logger.info({ tags : { foo : "bar" }, msg : "Error" });
+logger.info({ tags: { foo: "bar" }, msg: "Error" });
 
 // add extra
-logger.info({ extra : { foo : "bar" }, msg : "Error" });
+logger.info({ extra: { foo: "bar" }, msg: "Error" });
 
 // add breadcrumbs
 // https://docs.sentry.io/platforms/node/enriching-events/breadcrumbs/
@@ -56,7 +58,7 @@ logger.info({
       message: "Authenticated user " + user.email,
       level: "info",
     },
-  ]
+  ],
 });
 ```
 
@@ -66,10 +68,10 @@ logger.info({
 
 In case the generated message does not follow the standard convention, the main attribute keys can be mapped to different values, when the stream gets created. Following attribute keys can be overridden:
 
-* `msg`
-* `extra`
-* `stack`
-* `maxValueLength` - option to adjust max string length for values, default is 250
+- `msg`
+- `extra`
+- `stack`
+- `maxValueLength` - option to adjust max string length for values, default is 250
 
 ```js
 const { createWriteStream } = require('pino-sentry');
@@ -81,19 +83,20 @@ const stream = createWriteStream({
   stackAttributeKey: 'trace',
   extraAttributeKeys: ['req', 'context'],
   maxValueLength: 250,
+  sentryExceptionLevels?: Sentry.Severity['fatal', 'error', 'warning'];
 });
 const logger = pino(opts, stream);
 ```
 
 ### Transport options
 
-* `--dsn` (`-d`): your Sentry DSN or Data Source Name (defaults to `process.env.SENTRY_DSN`)
-* `--environment` (`-e`): (defaults to `process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'production'`)
-* `--serverName` (`-n`): transport name (defaults to `pino-sentry`)
-* `--debug` (`-dm`): turns debug mode on or off (default to `process.env.SENTRY_DEBUG || false`)
-* `--sampleRate` (`-sr`): sample rate as a percentage of events to be sent in the range of 0.0 to 1.0 (default to `1.0`)
-* `--maxBreadcrumbs` (`-mx`): total amount of breadcrumbs that should be captured (default to `100`)
-* `--level` (`-l`): minimum level for a log to be reported to Sentry (default to `debug`)
+- `--dsn` (`-d`): your Sentry DSN or Data Source Name (defaults to `process.env.SENTRY_DSN`)
+- `--environment` (`-e`): (defaults to `process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'production'`)
+- `--serverName` (`-n`): transport name (defaults to `pino-sentry`)
+- `--debug` (`-dm`): turns debug mode on or off (default to `process.env.SENTRY_DEBUG || false`)
+- `--sampleRate` (`-sr`): sample rate as a percentage of events to be sent in the range of 0.0 to 1.0 (default to `1.0`)
+- `--maxBreadcrumbs` (`-mx`): total amount of breadcrumbs that should be captured (default to `100`)
+- `--level` (`-l`): minimum level for a log to be reported to Sentry (default to `debug`)
 
 ### Log Level Mapping
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -51,6 +51,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   extraAttributeKeys?: string[];
   stackAttributeKey?: string;
   maxValueLength?: number;
+  sentryExceptionLevels?: Sentry.Severity[];
 }
 
 export class PinoSentryTransport {
@@ -60,6 +61,7 @@ export class PinoSentryTransport {
   extraAttributeKeys = ['extra'];
   stackAttributeKey = 'stack';
   maxValueLength = 250;
+  sentryExceptionLevels = [Sentry.Severity.Fatal,Sentry.Severity.Error];
 
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
@@ -167,6 +169,7 @@ export class PinoSentryTransport {
     this.extraAttributeKeys = options.extraAttributeKeys ?? this.extraAttributeKeys;
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
     this.maxValueLength = options.maxValueLength ?? this.maxValueLength;
+    this.sentryExceptionLevels = options.sentryExceptionLevels ?? this.sentryExceptionLevels;
 
     return {
       dsn,
@@ -187,7 +190,7 @@ export class PinoSentryTransport {
   }
 
   private isSentryException(level: Sentry.Severity): boolean {
-    return level === Sentry.Severity.Fatal || level === Sentry.Severity.Error;
+    return this.sentryExceptionLevels.includes(level);
   }
 
   private shouldLog(severity: Sentry.Severity): boolean {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -52,6 +52,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   stackAttributeKey?: string;
   maxValueLength?: number;
   sentryExceptionLevels?: Sentry.Severity[];
+  decorateScope?: (data: Record<string, unknown>, _scope: Sentry.Scope) => void;
 }
 
 export class PinoSentryTransport {
@@ -62,6 +63,7 @@ export class PinoSentryTransport {
   stackAttributeKey = 'stack';
   maxValueLength = 250;
   sentryExceptionLevels = [Sentry.Severity.Fatal,Sentry.Severity.Error];
+  decorateScope = (_data: Record<string, unknown>, _scope: Sentry.Scope) => {};
 
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
@@ -115,6 +117,7 @@ export class PinoSentryTransport {
     const stack = chunk[this.stackAttributeKey] || '';
 
     const scope = new Sentry.Scope();
+    this.decorateScope(chunk, scope);
 
     scope.setLevel(severity);
 
@@ -170,6 +173,7 @@ export class PinoSentryTransport {
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
     this.maxValueLength = options.maxValueLength ?? this.maxValueLength;
     this.sentryExceptionLevels = options.sentryExceptionLevels ?? this.sentryExceptionLevels;
+    this.decorateScope = options.decorateScope ?? this.decorateScope;
 
     return {
       dsn,


### PR DESCRIPTION
Add two options 

* sentryExceptionLevels

An option that allow to choose the sentry levels of the log to send as exceptions compared to the logs.
This new option is optional and without value, the behaviour will be the same than previously.

* decorateScope

That allow to mutate the scope before sending the exception or message to sentry

Sorry for the reformat of the markdown, my linter did it itself, I kept its changes because I find them relevant