### PR TITLE
Add options to pino sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # pino-sentry
+
 [![CircleCI](https://circleci.com/gh/aandrewww/pino-sentry.svg?style=svg)](https://circleci.com/gh/aandrewww/pino-sentry)
 [![node](https://img.shields.io/badge/node-6.4.0+-brightgreen.svg)][node-url]
 [![license](https://img.shields.io/github/license/aandrewww/pino-sentry.svg)][license-url]
@@ -8,14 +8,14 @@ Load [pino](https://github.com/pinojs/pino) logs into [Sentry](https://sentry.io
 
 ## Index
 
-* [Install](#install)
-* [Usage](#usage)
+- [Install](#install)
+- [Usage](#usage)
   - [CLI](#cli)
   - [API](#api)
-* [Options](#options-options)
+- [Options](#options-options)
   - [Transport options](#transport-options)
   - [Log Level Mapping](#log-level-mapping)
-* [License](#license)
+- [License](#license)
 
 ## Install
 
@@ -34,17 +34,19 @@ node ./app.js | pino-sentry --dsn=https://******@sentry.io/12345
 ### API
 
 ```js
-const { createWriteStream } = require('pino-sentry');
+const { createWriteStream, Sentry } = require("pino-sentry");
 // ...
-const opts = { /* ... */ };
+const opts = {
+  /* ... */
+};
 const stream = createWriteStream({ dsn: process.env.SENTRY_DSN });
 const logger = pino(opts, stream);
 
 // add tags
-logger.info({ tags : { foo : "bar" }, msg : "Error" });
+logger.info({ tags: { foo: "bar" }, msg: "Error" });
 
 // add extra
-logger.info({ extra : { foo : "bar" }, msg : "Error" });
+logger.info({ extra: { foo: "bar" }, msg: "Error" });
 
 // add breadcrumbs
 // https://docs.sentry.io/platforms/node/enriching-events/breadcrumbs/
@@ -56,7 +58,16 @@ logger.info({
       message: "Authenticated user " + user.email,
       level: "info",
     },
-  ]
+  ],
+});
+
+// the sentry instance is exposed and can be used to manipulate the same sentry than pino-sentry
+Sentry.addBreadcrumb({
+  category: "custom-logger",
+  message: "Hey there!",
+  level: "debug",
+  type: "debug",
+  data: { some: "data" },
 });
 ```
 
@@ -66,20 +77,22 @@ logger.info({
 
 In case the generated message does not follow the standard convention, the main attribute keys can be mapped to different values, when the stream gets created. Following attribute keys can be overridden:
 
-* `msg`
-* `extra`
-* `stack`
-* `maxValueLength` - option to adjust max string length for values, default is 250
+- `msg`
+- `extra`
+- `stack`
+- `maxValueLength` - option to adjust max string length for values, default is 250
 
 ```js
-const { createWriteStream } = require('pino-sentry');
+const { createWriteStream } = require("pino-sentry");
 // ...
-const opts = { /* ... */ };
+const opts = {
+  /* ... */
+};
 const stream = createWriteStream({
   dsn: process.env.SENTRY_DSN,
-  messageAttributeKey: 'message',
-  stackAttributeKey: 'trace',
-  extraAttributeKeys: ['req', 'context'],
+  messageAttributeKey: "message",
+  stackAttributeKey: "trace",
+  extraAttributeKeys: ["req", "context"],
   maxValueLength: 250,
 });
 const logger = pino(opts, stream);
@@ -87,13 +100,13 @@ const logger = pino(opts, stream);
 
 ### Transport options
 
-* `--dsn` (`-d`): your Sentry DSN or Data Source Name (defaults to `process.env.SENTRY_DSN`)
-* `--environment` (`-e`): (defaults to `process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'production'`)
-* `--serverName` (`-n`): transport name (defaults to `pino-sentry`)
-* `--debug` (`-dm`): turns debug mode on or off (default to `process.env.SENTRY_DEBUG || false`)
-* `--sampleRate` (`-sr`): sample rate as a percentage of events to be sent in the range of 0.0 to 1.0 (default to `1.0`)
-* `--maxBreadcrumbs` (`-mx`): total amount of breadcrumbs that should be captured (default to `100`)
-* `--level` (`-l`): minimum level for a log to be reported to Sentry (default to `debug`)
+- `--dsn` (`-d`): your Sentry DSN or Data Source Name (defaults to `process.env.SENTRY_DSN`)
+- `--environment` (`-e`): (defaults to `process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'production'`)
+- `--serverName` (`-n`): transport name (defaults to `pino-sentry`)
+- `--debug` (`-dm`): turns debug mode on or off (default to `process.env.SENTRY_DEBUG || false`)
+- `--sampleRate` (`-sr`): sample rate as a percentage of events to be sent in the range of 0.0 to 1.0 (default to `1.0`)
+- `--maxBreadcrumbs` (`-mx`): total amount of breadcrumbs that should be captured (default to `100`)
+- `--level` (`-l`): minimum level for a log to be reported to Sentry (default to `debug`)
 
 ### Log Level Mapping
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In case the generated message does not follow the standard convention, the main 
 - `stack`
 - `maxValueLength` - option to adjust max string length for values, default is 250
 - `decorateScope` - option to decorate, manipulate the sentry scope just before the capture
-- `sentryExceptionLevels` - option that represent the levels that will be handled as exceptions. Default : `error` and `fatal`
+- # `sentryExceptionLevels` - option that represent the levels that will be handled as exceptions. Default : `error` and `fatal`
 
 ```js
 const { createWriteStream, Sentry } = require("pino-sentry");

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Sentry.addBreadcrumb({
 
 In case the generated message does not follow the standard convention, the main attribute keys can be mapped to different values, when the stream gets created. Following attribute keys can be overridden:
 
-- `msg`
+- `msg` - the field used to get the message, it can be dot notted (eg 'data.msg')
 - `extra`
-- `stack`
+- `stack` - the field used to get the stack, it can be dot notted (eg 'err.stack')
 - `maxValueLength` - option to adjust max string length for values, default is 250
 - `decorateScope` - option to decorate, manipulate the sentry scope just before the capture
 - # `sentryExceptionLevels` - option that represent the levels that will be handled as exceptions. Default : `error` and `fatal`

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ In case the generated message does not follow the standard convention, the main 
 - `extra`
 - `stack`
 - `maxValueLength` - option to adjust max string length for values, default is 250
+- `decorateScope` - option to decorate, manipulate the sentry scope just before the capture
+- `sentryExceptionLevels` - option that represent the levels that will be handled as exceptions. Default : `error` and `fatal`
 
 ```js
-const { createWriteStream } = require("pino-sentry");
+const { createWriteStream, Sentry } = require("pino-sentry");
 // ...
 const opts = {
   /* ... */
@@ -94,6 +96,14 @@ const stream = createWriteStream({
   stackAttributeKey: "trace",
   extraAttributeKeys: ["req", "context"],
   maxValueLength: 250,
+  sentryExceptionLevels: [
+    Sentry.Severity.Warning,
+    Sentry.Severity.Error,
+    Sentry.Severity.Fatal,
+  ],
+  decorateScope: (data, scope) => {
+    scope.setUser("userId", { id: data.userId });
+  },
 });
 const logger = pino(opts, stream);
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { createWriteStream, createWriteStreamAsync } from './transport';
+export { createWriteStream, createWriteStreamAsync, SentryInstance as Sentry } from './transport';

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -56,6 +56,10 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   decorateScope?: (data: Record<string, unknown>, _scope: Sentry.Scope) => void;
 }
 
+function get(data: any, path: string) {
+  return path.split('.').reduce((acc, part) => acc && acc[part], data);
+}
+
 export class PinoSentryTransport {
   // Default minimum log level to `debug`
   minimumLogLevel: ValueOf<typeof SeverityIota> = SeverityIota[Sentry.Severity.Debug]
@@ -114,8 +118,8 @@ export class PinoSentryTransport {
         extra[key] = chunk[key];
       }
     });
-    const message = chunk[this.messageAttributeKey];
-    const stack = chunk[this.stackAttributeKey] || '';
+    const message = get(chunk, this.messageAttributeKey);
+    const stack = get(chunk, this.stackAttributeKey) || '';
 
     const scope = new Sentry.Scope();
     this.decorateScope(chunk, scope);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -7,6 +7,7 @@ import { Breadcrumb } from '@sentry/types';
 
 type ValueOf<T> = T extends any[] ? T[number] : T[keyof T]
 
+export const SentryInstance = Sentry;
 class ExtendedError extends Error {
   public constructor(info: any) {
     super(info.message);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -53,6 +53,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   stackAttributeKey?: string;
   maxValueLength?: number;
   sentryExceptionLevels?: Sentry.Severity[];
+  decorateScope?: (data: Record<string, unknown>, _scope: Sentry.Scope) => void;
 }
 
 export class PinoSentryTransport {
@@ -63,6 +64,7 @@ export class PinoSentryTransport {
   stackAttributeKey = 'stack';
   maxValueLength = 250;
   sentryExceptionLevels = [Sentry.Severity.Fatal,Sentry.Severity.Error];
+  decorateScope = (_data: Record<string, unknown>, _scope: Sentry.Scope) => {};
 
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
@@ -116,6 +118,7 @@ export class PinoSentryTransport {
     const stack = chunk[this.stackAttributeKey] || '';
 
     const scope = new Sentry.Scope();
+    this.decorateScope(chunk, scope);
 
     scope.setLevel(severity);
 
@@ -171,6 +174,7 @@ export class PinoSentryTransport {
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
     this.maxValueLength = options.maxValueLength ?? this.maxValueLength;
     this.sentryExceptionLevels = options.sentryExceptionLevels ?? this.sentryExceptionLevels;
+    this.decorateScope = options.decorateScope ?? this.decorateScope;
 
     return {
       dsn,

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -52,6 +52,7 @@ interface PinoSentryOptions extends Sentry.NodeOptions {
   extraAttributeKeys?: string[];
   stackAttributeKey?: string;
   maxValueLength?: number;
+  sentryExceptionLevels?: Sentry.Severity[];
 }
 
 export class PinoSentryTransport {
@@ -61,6 +62,7 @@ export class PinoSentryTransport {
   extraAttributeKeys = ['extra'];
   stackAttributeKey = 'stack';
   maxValueLength = 250;
+  sentryExceptionLevels = [Sentry.Severity.Fatal,Sentry.Severity.Error];
 
   public constructor(options?: PinoSentryOptions) {
     Sentry.init(this.validateOptions(options || {}));
@@ -168,6 +170,7 @@ export class PinoSentryTransport {
     this.extraAttributeKeys = options.extraAttributeKeys ?? this.extraAttributeKeys;
     this.messageAttributeKey = options.messageAttributeKey ?? this.messageAttributeKey;
     this.maxValueLength = options.maxValueLength ?? this.maxValueLength;
+    this.sentryExceptionLevels = options.sentryExceptionLevels ?? this.sentryExceptionLevels;
 
     return {
       dsn,
@@ -188,7 +191,7 @@ export class PinoSentryTransport {
   }
 
   private isSentryException(level: Sentry.Severity): boolean {
-    return level === Sentry.Severity.Fatal || level === Sentry.Severity.Error;
+    return this.sentryExceptionLevels.includes(level);
   }
 
   private shouldLog(severity: Sentry.Severity): boolean {


### PR DESCRIPTION
Add a few options to pino-sentry

* `decorateScope` that permit to manipulate the scope
* `sentryExceptionLevels` that permit to set the level of logs that need to be captured as error

expose the Sentry instance