### PR TITLE
Export PinoSentryOptions for public

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { createWriteStream, createWriteStreamAsync, SentryInstance as Sentry } from './transport';
+export {
+  createWriteStream,
+  createWriteStreamAsync,
+  SentryInstance as Sentry,
+} from './transport';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export {
   createWriteStream,
   createWriteStreamAsync,
   SentryInstance as Sentry,
+  PinoSentryOptions,
 } from './transport';

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -45,7 +45,7 @@ const SeverityIota  = {
   [Sentry.Severity.Critical]: 7,
 } as const;
 
-interface PinoSentryOptions extends Sentry.NodeOptions {
+export interface PinoSentryOptions extends Sentry.NodeOptions {
   /** Minimum level for a log to be reported to Sentry from pino-sentry */
   level?: keyof typeof SeverityIota;
   messageAttributeKey?: string;


### PR DESCRIPTION
This allows using explcit typing when building options for `createWriteStream`:

```ts
    const sentryOptions: PinoSentryOptions = {
      dsn,
      release: Context.getVersion(),
      serverName: Context.getNodeName(),
      onFatalError: options.sentry?.errorHandler,
      // https://docs.sentry.io/platforms/node/configuration/integrations/
      integrations: [
        new Integrations.Modules(),
      ],
    };

    if (options.sentry_environment) {
      sentryOptions.environment = options.sentry_environment;
    }

    return createSentryStream(sentryOptions);
```