### PR TITLE
Allow @sentry/node 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Load [pino](https://github.com/pinojs/pino) logs into [Sentry](https://sentry.io
 npm install pino-sentry -g
 ```
 
+Note: The v7 version of the Sentry JavaScript SDK requires a self-hosted
+version of Sentry 20.6.0 or higher. If you are using a version of self-hosted
+Sentry (aka onpremise) older than 20.6.0 then you will need to upgrade. See
+[sentry-javascript@7.0.0] release notes.
+
+Alternatively you can pin `@sentry/*` packages to 6.x.
+
+[sentry-javascript@7.0.0]: https://github.com/getsentry/sentry-javascript/releases/tag/7.0.0
+
 ## Usage
 
 ### CLI

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In case the generated message does not follow the standard convention, the main 
 - `sentryExceptionLevels` - option that represent the levels that will be handled as exceptions. Default : `error` and `fatal`
 
 ```js
-const { createWriteStream, Sentry } = require("pino-sentry");
+const { createWriteStream, Severity } = require("pino-sentry");
 // ...
 const opts = {
   /* ... */
@@ -106,9 +106,9 @@ const stream = createWriteStream({
   extraAttributeKeys: ["req", "context"],
   maxValueLength: 250,
   sentryExceptionLevels: [
-    Sentry.Severity.Warning,
-    Sentry.Severity.Error,
-    Sentry.Severity.Fatal,
+    Severity.Warning,
+    Severity.Error,
+    Severity.Fatal,
   ],
   decorateScope: (data, scope) => {
     scope.setUser("userId", { id: data.userId });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@sentry/node": "^6.2.5",
+        "@sentry/node": "^6.2.5||^7.1.1",
         "commander": "^2.20.0",
         "pumpify": "^2.0.1",
         "split2": "^3.1.1",
@@ -1302,98 +1302,68 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.1.1.tgz",
+      "integrity": "sha512-SADdAoG5u1LTJhPN5KPtn5HHmH6r0mr6h2LokuZnhj6/okrAuCIIKOb6Fh8jV7j2VuABvew8+FjJHORxi7D/3Q==",
       "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/hub": "7.1.1",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.1.1.tgz",
+      "integrity": "sha512-ASsRVjYDIii6ZTf36JnIYKHWBQBk0P42Tgq324MpyPgaeVDg3saBcyXO5iAtWvY6Vmdi2H4JCVDoir2Zz3Me1w==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
-      "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.5.tgz",
-      "integrity": "sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.1.1.tgz",
+      "integrity": "sha512-QD9KPzVNu4zCL2Rjd5Go2/bjiuR9PLSutX7MkngHdGfy6JnN8CixTAXCjEyxb3oexI9xQyzgrQqns+UP5jdnlA==",
       "dependencies": {
-        "@sentry/core": "6.2.5",
-        "@sentry/hub": "6.2.5",
-        "@sentry/tracing": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/core": "7.1.1",
+        "@sentry/hub": "7.1.1",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.5.tgz",
-      "integrity": "sha512-j/hM0BoHxfrNLxPeEJ5Vq4R34hO/TOHMEpLR3FdnunBXbsmjoKMMygIkPxnpML5XWtvukAehbwpDXldwMYz83w==",
-      "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-5N1UMd2SqvUXprcIUMyDEju3H9lJY2oWfWQBGo0lG6Amn/lGAPAYlchg+4vQCLutDQMyd8K9zPwcbKn4u6gHdw==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.1.1.tgz",
+      "integrity": "sha512-DPRHDf3InfyVgmxToE4Z+AATAR4OVm+wsXDLFGGyncR91CE1x4wLQKOcAJJwX3F0Hz1VHENfmx1DvyYTHOrC/A==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
+        "@sentry/types": "7.1.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -7760,76 +7730,52 @@
       }
     },
     "@sentry/core": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.1.1.tgz",
+      "integrity": "sha512-SADdAoG5u1LTJhPN5KPtn5HHmH6r0mr6h2LokuZnhj6/okrAuCIIKOb6Fh8jV7j2VuABvew8+FjJHORxi7D/3Q==",
       "requires": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/hub": "7.1.1",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.1.1.tgz",
+      "integrity": "sha512-ASsRVjYDIii6ZTf36JnIYKHWBQBk0P42Tgq324MpyPgaeVDg3saBcyXO5iAtWvY6Vmdi2H4JCVDoir2Zz3Me1w==",
       "requires": {
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
-      "requires": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/types": "6.2.5",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.5.tgz",
-      "integrity": "sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.1.1.tgz",
+      "integrity": "sha512-QD9KPzVNu4zCL2Rjd5Go2/bjiuR9PLSutX7MkngHdGfy6JnN8CixTAXCjEyxb3oexI9xQyzgrQqns+UP5jdnlA==",
       "requires": {
-        "@sentry/core": "6.2.5",
-        "@sentry/hub": "6.2.5",
-        "@sentry/tracing": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/core": "7.1.1",
+        "@sentry/hub": "7.1.1",
+        "@sentry/types": "7.1.1",
+        "@sentry/utils": "7.1.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       }
     },
-    "@sentry/tracing": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.5.tgz",
-      "integrity": "sha512-j/hM0BoHxfrNLxPeEJ5Vq4R34hO/TOHMEpLR3FdnunBXbsmjoKMMygIkPxnpML5XWtvukAehbwpDXldwMYz83w==",
-      "requires": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/types": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-5N1UMd2SqvUXprcIUMyDEju3H9lJY2oWfWQBGo0lG6Amn/lGAPAYlchg+4vQCLutDQMyd8K9zPwcbKn4u6gHdw=="
     },
     "@sentry/utils": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.1.1.tgz",
+      "integrity": "sha512-DPRHDf3InfyVgmxToE4Z+AATAR4OVm+wsXDLFGGyncR91CE1x4wLQKOcAJJwX3F0Hz1VHENfmx1DvyYTHOrC/A==",
       "requires": {
-        "@sentry/types": "6.2.5",
+        "@sentry/types": "7.1.1",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@sentry/node": "^6.2.5",
+    "@sentry/node": "^6.2.5||^7.1.1",
     "commander": "^2.20.0",
     "pumpify": "^2.0.1",
     "split2": "^3.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ function main() {
     .option('--maxValueLength <maxValueLength>', 'Maximum number of chars a single value can have before it will be truncated.')
     .option('--release <release>', 'The release identifier used when uploading respective source maps.')
     .option('-l, --level <level>', 'The minimum level for a log to be reported to Sentry')
-    .action(({ dsn, serverName, environment, debug, sampleRate, maxBreadcrumbs, dist, logLevel, maxValueLength, release, level }) => {
+    .action(({ dsn, serverName, environment, debug, sampleRate, maxBreadcrumbs, dist, maxValueLength, release, level }) => {
       try {
         const writeStream = createWriteStream({
           dsn,
@@ -29,7 +29,6 @@ function main() {
           sampleRate,
           maxBreadcrumbs,
           dist,
-          logLevel,
           maxValueLength,
           release,
           level,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export {
   createWriteStreamAsync,
   SentryInstance as Sentry,
   PinoSentryOptions,
+  Severity,
 } from './transport';

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -25,6 +25,8 @@ enum Severity {
   Log = "log",
   Info = "info",
   Debug = "debug",
+  // @deprecated: "critical" is not present in sentry 7.x sdk
+  // https://github.com/getsentry/sentry-javascript/issues/3067
   Critical = "critical",
 }
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -18,7 +18,7 @@ class ExtendedError extends Error {
 }
 
 // Local enum declaration, as @sentry/node deprecated using enums over strings for bundle size
-enum Severity {
+export enum Severity {
   Fatal = "fatal",
   Error = "error",
   Warning = "warning",


### PR DESCRIPTION
- https://github.com/getsentry/sentry-javascript/releases/tag/7.0.0:
> Note: The v7 version of the JavaScript SDK requires a self-hosted version of Sentry 20.6.0 or higher. If you are using a version of [self-hosted Sentry](https://develop.sentry.dev/self-hosted/) (aka onpremise) older than 20.6.0 then you will need to [upgrade](https://develop.sentry.dev/self-hosted/releases/).

- https://github.com/getsentry/sentry-javascript/blob/7.0.0/MIGRATION.md#upgrading-from-6x-to-7x

Notes:
- `logLevel` is dropped because it wasn't ever declared as option in 33f8443fa6df669e540923a604027911d57173ea. it's also not present in 6.x
- `Severity` enum is added because 7.x deprecates it in favour of bundle size and switched to strings
-  `"critical"` is not present in sentry 7.x SDK: https://github.com/getsentry/sentry-javascript/issues/3067#issuecomment-1095498784