### PR TITLE
Setup GitHub action to run build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build TypeScript
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build package
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: npm
+      - run: npm ci
+      - run: npm run-script build
+
+# vim:ts=2:sw=2:et


### PR DESCRIPTION
Use simple instruction from https://github.com/actions/setup-node

This replaces CircleCI integration:
- https://github.com/aandrewww/pino-sentry/blob/62471b5a1a8b53d7ad5fc2aeaac7a0f01485c1e4/circle.yml#L20

The CircleCI integration is broken and should be removed once this is merged:
- https://github.com/aandrewww/pino-sentry/pull/46#issuecomment-1169123672

Example run:
- https://github.com/glensc/node-pino-sentry/actions/runs/2578937334

Future steps:
- https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

