### PR TITLE
allow nesting in extra attribute keys

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -134,8 +134,9 @@ export class PinoSentryTransport {
 
     const extra: any = {};
     this.extraAttributeKeys.forEach((key: string) => {
-      if(chunk[key] !== undefined) {
-        extra[key] = chunk[key];
+      const value = get(chunk, key);
+      if(value !== undefined) {
+        extra[key] = value;
       }
     });
     const message: any & Error = get(chunk, this.messageAttributeKey);


### PR DESCRIPTION
PR for issue #58.
Allowing nested paths for the extraAttributeKeys.

For example, for this payload
```
logger.error({
    field1: 'Field1',
    extraData: {
        name: 'data name',
        id: '123',
    }
}, 'some error message');
```
Giving 
```
extraAttributeKeys: ["extraData.id", "field1"]
```
would ignore the extraData.id since it did not parse and split the path, and you would get only the `field1` as an additional data in the sentry side.  
Now you would get both `extraData.id` and `field1`.
